### PR TITLE
Fix expense category loading and clean up lint

### DIFF
--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Brain, Camera, CheckCircle, CreditCard, BarChart3, Users, Shield, Zap } from 'lucide-react';
+import { Brain, CheckCircle, CreditCard, BarChart3, Users, Shield, Zap } from 'lucide-react';
 
 const Features: React.FC = () => {
   const features = [

--- a/src/components/app/AddExpense.tsx
+++ b/src/components/app/AddExpense.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Plus, Calendar, MapPin, PoundSterling, FileText, Check, Camera, Image, X, FolderOpen } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
@@ -34,15 +34,7 @@ const AddExpense: React.FC = () => {
     amount: '',
   });
 
-  // Load claims on component mount
-  React.useEffect(() => {
-    if (user) {
-      loadClaims();
-      loadCategories();
-    }
-  }, [user]);
-
-  const loadClaims = async () => {
+  const loadClaims = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -57,9 +49,9 @@ const AddExpense: React.FC = () => {
     } catch (error) {
       console.error('Error loading claims:', error);
     }
-  };
+  }, [user]);
 
-  const loadCategories = async () => {
+  const loadCategories = useCallback(async () => {
     if (!user || !profile?.company_id) {
       setCategories([]);
       return;
@@ -77,7 +69,21 @@ const AddExpense: React.FC = () => {
     } catch (error) {
       console.error('Error loading categories:', error);
     }
-  };
+  }, [user, profile?.company_id]);
+
+  React.useEffect(() => {
+    if (user) {
+      loadClaims();
+    }
+  }, [user, loadClaims]);
+
+  React.useEffect(() => {
+    if (user && profile?.company_id) {
+      loadCategories();
+    } else {
+      setCategories([]);
+    }
+  }, [user, profile?.company_id, loadCategories]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setFormData({

--- a/src/components/app/Settings.tsx
+++ b/src/components/app/Settings.tsx
@@ -48,14 +48,14 @@ const Settings: React.FC = () => {
     }
   }, [user]);
 
-  useEffect(() => {
-    if (profile) {
-      setProfileData({
-        full_name: profile.full_name || '',
-        avatar_url: (profile as any).avatar_url || '',
-      });
-    }
-  }, [profile]);
+    useEffect(() => {
+      if (profile) {
+        setProfileData({
+          full_name: profile.full_name || '',
+          avatar_url: profile.avatar_url || '',
+        });
+      }
+    }, [profile]);
 
   // Resolve a signed URL for stored avatar path when profileData.avatar_url changes
   useEffect(() => {
@@ -126,12 +126,14 @@ const Settings: React.FC = () => {
         // Store the storage path (not a public URL) for RLS-compatible access
         avatarUrl = filePath;
         // Also refresh signed URL for immediate preview after upload
-        try {
-          const { data } = await supabase.storage
-            .from('images')
-            .createSignedUrl(filePath, 60 * 60);
-          setAvatarSignedUrl(data?.signedUrl || null);
-        } catch {}
+          try {
+            const { data } = await supabase.storage
+              .from('images')
+              .createSignedUrl(filePath, 60 * 60);
+            setAvatarSignedUrl(data?.signedUrl || null);
+          } catch (error) {
+            console.error('Error creating signed URL after upload:', error);
+          }
         setUploading(false);
       }
 

--- a/src/components/app/ViewExpenses.tsx
+++ b/src/components/app/ViewExpenses.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Receipt, Edit3, Trash2, MapPin, Calendar, PoundSterling, Search, Image, Download, FileCheck, FileX, Plus, FolderOpen, ChevronDown, ChevronRight } from 'lucide-react';
+import { Receipt, Edit3, Trash2, MapPin, Calendar, Search, Image, Download, FileCheck, FileX, Plus, FolderOpen, ChevronDown, ChevronRight } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
 import EditExpenseModal from './EditExpenseModal';
@@ -18,7 +18,6 @@ interface Expense {
   image_url: string | null;
   filed: boolean;
   created_at: string;
-  filed: boolean;
 }
 
 interface Claim {
@@ -245,8 +244,8 @@ const ViewExpenses: React.FC = () => {
         'Created At'
       ]);
 
-      // Process each expense
-      filteredExpenses.forEach((expense, index) => {
+        // Process each expense
+        filteredExpenses.forEach(expense => {
         const imageFilename = expense.image_url ? `expense_${expense.id}.jpg` : '';
         const claimTitle = expense.claim_id 
           ? claims.find(c => c.id === expense.claim_id)?.title || 'Unknown Claim'

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -35,6 +35,7 @@ export function useAuth() {
           setProfile(null);
         }
       } catch (error) {
+        console.error('Error fetching initial session:', error);
         setUser(null);
         setProfile(null);
       } finally {
@@ -131,6 +132,7 @@ export function useAuth() {
       
       return !!session;
     } catch (error) {
+      console.error('Error validating session:', error);
       await supabase.auth.signOut();
       setUser(null);
       return false;


### PR DESCRIPTION
## Summary
- Ensure AddExpense reloads expense categories when the user profile changes
- Improve Settings and auth error handling and tidy unused imports
- Remove duplicate fields and unused parameters in expense views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a124ade883288907af34db68d87d